### PR TITLE
feat: Implement message fragmentation and reassembly

### DIFF
--- a/bitchat-rust/Cargo.lock
+++ b/bitchat-rust/Cargo.lock
@@ -510,6 +510,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,10 +546,13 @@ dependencies = [
  "bincode",
  "bitflags 2.9.3",
  "btleplug",
+ "chrono",
+ "ed25519-dalek",
  "eframe",
  "futures",
  "rand",
  "serde",
+ "serde_bytes",
  "serde_with",
  "sha2",
  "snow",
@@ -869,8 +878,10 @@ checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -991,6 +1002,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1106,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
+ "digest",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1193,6 +1211,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,6 +1316,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20930a432bbd57a6d55e07976089708d4893f3d556cf42a0d79e9e321fa73b10"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "serde",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2879,6 +2933,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3332,6 +3396,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3441,6 +3514,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -3584,6 +3666,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
  "bitflags 2.9.3",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]

--- a/bitchat-rust/Cargo.toml
+++ b/bitchat-rust/Cargo.toml
@@ -18,3 +18,6 @@ uuid = { version = "1.8", features = ["v4", "serde"] }
 serde_with = "3.8"
 futures = "0.3"
 rand = "0.8"
+ed25519-dalek = { version = "2.1", features = ["serde", "rand_core"] }
+serde_bytes = "0.11"
+chrono = { version = "0.4", features = ["serde"] }

--- a/bitchat-rust/src/identity.rs
+++ b/bitchat-rust/src/identity.rs
@@ -1,0 +1,69 @@
+//! Manages user identity, including keypairs for encryption and signing.
+
+use ed25519_dalek::{SigningKey, KEYPAIR_LENGTH};
+use serde::{Serialize, Deserialize};
+
+/// A serializable version of the `snow::Keypair` struct.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SerializableKeypair {
+    pub private: Vec<u8>,
+    pub public: Vec<u8>,
+}
+
+impl From<snow::Keypair> for SerializableKeypair {
+    fn from(keys: snow::Keypair) -> Self {
+        Self { private: keys.private, public: keys.public }
+    }
+}
+
+/// A serializable version of the `ed25519_dalek::SigningKey` struct.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SerializableSigningKeypair {
+    #[serde(with = "serde_bytes")]
+    pub keypair_bytes: [u8; KEYPAIR_LENGTH],
+}
+
+impl From<&SigningKey> for SerializableSigningKeypair {
+    fn from(keys: &SigningKey) -> Self {
+        Self { keypair_bytes: keys.to_keypair_bytes() }
+    }
+}
+
+/// Represents a user's identity, containing the necessary cryptographic keys.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct UserIdentity {
+    /// Keypair for the Noise Protocol (XX pattern).
+    /// This is used for establishing encrypted sessions.
+    pub noise_keypair: SerializableKeypair,
+    /// Keypair for signing messages and announcements.
+    pub signing_keypair: SerializableSigningKeypair,
+}
+
+impl UserIdentity {
+    /// Generates a new identity with fresh keypairs.
+    pub fn generate() -> Result<Self, snow::Error> {
+        let builder = snow::Builder::new("Noise_XX_25519_ChaChaPoly_SHA256".parse()?);
+        let noise_keypair = builder.generate_keypair()?.into();
+
+        let mut csprng = rand::rngs::OsRng{};
+        let signing_key: SigningKey = SigningKey::generate(&mut csprng);
+
+        Ok(Self {
+            noise_keypair,
+            signing_keypair: (&signing_key).into(),
+        })
+    }
+
+    /// Saves the identity to a file in binary format.
+    pub fn save_to_file(&self, path: &str) -> Result<(), std::io::Error> {
+        let encoded = bincode::serialize(self).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        std::fs::write(path, encoded)
+    }
+
+    /// Loads an identity from a file.
+    pub fn load_from_file(path: &str) -> Result<Self, std::io::Error> {
+        let data = std::fs::read(path)?;
+        let decoded = bincode::deserialize(&data).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        Ok(decoded)
+    }
+}


### PR DESCRIPTION
This commit adds support for sending and receiving messages larger than the BLE transport's MTU by implementing packet fragmentation and reassembly.

Key changes:
- Defines `FragmentPacket` in the protocol.
- Implements a `send_packet_fragmented` function in `NetworkManager` to automatically split large packets.
- Implements logic to receive, buffer, and reassemble fragments.
- Refactors sending and relaying logic to use the new fragmentation function.
- Resolves several borrow-checker and async recursion issues related to the new logic.