### PR TITLE
feat: Add geohash feature and rename channel

### DIFF
--- a/bitchat-rust/Cargo.lock
+++ b/bitchat-rust/Cargo.lock
@@ -550,6 +550,8 @@ dependencies = [
  "ed25519-dalek",
  "eframe",
  "futures",
+ "geo",
+ "geohash",
  "rand",
  "serde",
  "serde_bytes",
@@ -1761,6 +1763,21 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "geo"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07df8f0626d9776adb4d3adc0eaf7d089ae28e7165a4fc26743f3a35cd89f3f"
+
+[[package]]
+name = "geohash"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f4a2446181449e4b4ee0b49a348372b70ab7630397e6f64cece65ee91886b3"
+dependencies = [
+ "geo",
 ]
 
 [[package]]

--- a/bitchat-rust/Cargo.toml
+++ b/bitchat-rust/Cargo.toml
@@ -3,6 +3,9 @@ name = "bitchat-rust"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+geohash = []
+
 [dependencies]
 eframe = "0.27"
 tokio = { version = "1", features = ["full"] }
@@ -21,3 +24,5 @@ rand = "0.8"
 ed25519-dalek = { version = "2.1", features = ["serde", "rand_core"] }
 serde_bytes = "0.11"
 chrono = { version = "0.4", features = ["serde"] }
+geohash = "0.2"
+geo = "0.0.7"

--- a/bitchat-rust/src/geohash.rs
+++ b/bitchat-rust/src/geohash.rs
@@ -1,0 +1,18 @@
+// src/geohash.rs
+
+use geohash::encode;
+use geo::Coordinate;
+use std::error::Error;
+
+pub fn get_current_geohash() -> Result<String, Box<dyn Error>> {
+    // ここではダミーの位置情報を使います
+    // 将来的に、OSから位置情報を取得するロジックに置き換えます
+    let lat = 35.6895; // 東京駅の緯度
+    let lon = 139.6917; // 東京駅の経度
+    let coord = Coordinate { x: lon, y: lat };
+
+    // ジオハッシュをエンコード（精度を指定）
+    let geohash_str = encode(coord, 6usize);
+
+    Ok(geohash_str)
+}

--- a/bitchat-rust/src/main.rs
+++ b/bitchat-rust/src/main.rs
@@ -13,6 +13,9 @@ pub mod ble;
 pub mod network;
 pub mod identity;
 
+#[cfg(feature = "geohash")]
+pub mod geohash;
+
 const IDENTITY_FILE: &str = "bitchat_identity.bin";
 
 #[tokio::main]
@@ -51,6 +54,14 @@ async fn main() -> Result<(), eframe::Error> {
     tokio::spawn(async move {
         network_manager.run().await;
     });
+
+    #[cfg(feature = "geohash")]
+    {
+        if let Ok(hash) = geohash::get_current_geohash() {
+            println!("Current Geohash: {}", hash);
+            // 将来的に、このハッシュをパケットに含める
+        }
+    }
 
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
@@ -202,7 +213,7 @@ impl eframe::App for MyApp {
         // Header
         egui::TopBottomPanel::top("header").show(ctx, |ui| {
             ui.horizontal(|ui| {
-                ui.label(egui::RichText::new("#public").font(egui::FontId::proportional(17.0)).strong());
+                ui.label(egui::RichText::new("#mesh").font(egui::FontId::proportional(17.0)).strong());
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     let users_button = ui.add(egui::Button::new(egui::RichText::new("👥").size(20.0)).frame(false));
                     if users_button.clicked() {


### PR DESCRIPTION
This commit introduces a new geohash feature, which is conditionally compiled using a feature flag. This allows for the development of the geohash functionality without affecting the main application until it is ready.

The geohash feature includes:
- New `geohash` and `geo` crate dependencies.
- A `geohash.rs` module with a function to get the current geohash.
- A `geohash` feature flag in `Cargo.toml`.
- Conditional compilation in `main.rs` to enable the feature.

To resolve compilation issues due to version incompatibilities, the `geo` crate has been pinned to an older version (`0.0.7`) that is compatible with the `geohash` crate (`0.2`).

Additionally, the public channel name has been changed from `#public` to `#mesh` in the UI.